### PR TITLE
arreglado pequeño bug en filtro de fechas

### DIFF
--- a/app/Http/Controllers/TarjetasController.php
+++ b/app/Http/Controllers/TarjetasController.php
@@ -53,9 +53,10 @@ class TarjetasController extends Controller
         }else{
           $tar->whereBetween('fecha_cierre', [$inicio, $fin])->get();
         }
-       
-     
-      }  
+            
+      }  else{
+        $filtro = 'crea';
+      }
       //filtro de tarjetas por status  
       if($status == null || $status == 'def'){
 


### PR DESCRIPTION
Cuando seleccionabas filtro de fechas por finalizacion, y los campos de fecha inicial y final estaban vacios, se hacia un cagadal, el cual arreglé!